### PR TITLE
Fix infinite paging bug.

### DIFF
--- a/pkg/client/helpers.go
+++ b/pkg/client/helpers.go
@@ -26,6 +26,9 @@ func logBody(ctx context.Context, bodyCloser io.ReadCloser) {
 // https://docs.sentry.io/api/pagination/
 func HasNextPage(res *http.Response) bool {
 	for _, l := range link.ParseResponse(res) {
+		if l.Rel != "next" {
+			continue
+		}
 		if v, ok := l.Extra["results"]; ok && v == "true" {
 			return true
 		}


### PR DESCRIPTION
I was adding the integration to C1 when I realized it never completed a sync. It was looking for a "next" on any link header and would use the "next" from a "previous" rel cursor so it never saw the end and would never sync.