### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-sentry/main.go
+++ b/cmd/baton-sentry/main.go
@@ -49,7 +49,7 @@ func getConnector[T field.Configurable](ctx context.Context, config T) (types.Co
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, config.GetString(cfg.ApiToken.FieldName))
+	cb, err := connector.New(ctx, config.GetString(cfg.ApiToken.FieldName), config.GetString(cfg.BaseURL.FieldName))
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -59,7 +59,7 @@ func New(ctx context.Context, apiToken string, baseURL string) (*Client, error) 
 		baseURL = DefaultBaseURL
 	}
 	if !strings.HasSuffix(baseURL, "/") {
-		baseURL = baseURL + "/"
+		baseURL += "/"
 	}
 
 	return &Client{

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
+
+const DefaultBaseURL = "https://sentry.io/api/0/"
 
 type sentryError struct {
 	Detail json.RawMessage `json:"detail"`
@@ -43,16 +46,25 @@ func (e *sentryError) Message() string {
 
 type Client struct {
 	*uhttp.BaseHttpClient
+	baseURL string
 }
 
-func New(ctx context.Context, apiToken string) (*Client, error) {
+func New(ctx context.Context, apiToken string, baseURL string) (*Client, error) {
 	httpClient, err := uhttp.NewBearerAuth(apiToken).GetClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
 	}
 
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL = baseURL + "/"
+	}
+
 	return &Client{
 		BaseHttpClient: uhttp.NewBaseHttpClient(httpClient),
+		baseURL:        baseURL,
 	}, nil
 }
 

--- a/pkg/client/organizations.go
+++ b/pkg/client/organizations.go
@@ -13,7 +13,7 @@ import (
 // docs: https://docs.sentry.io/api/organizations/
 
 func (c *Client) ListOrganizations(ctx context.Context, cursor string) ([]Organization, string, *v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, OrganizationsUrl, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.OrganizationsURL(), nil)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -39,7 +39,7 @@ func (c *Client) ListOrganizations(ctx context.Context, cursor string) ([]Organi
 
 // https://docs.sentry.io/api/guides/teams-tutorial/#list-an-organizations-teams-1
 func (c *Client) ListOrganizationMembers(ctx context.Context, orgID, cursor string) ([]OrganizationMember, string, *v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(OrganizationMembersUrl, orgID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.OrganizationMembersURL(orgID), nil)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -64,7 +64,7 @@ func (c *Client) ListOrganizationMembers(ctx context.Context, orgID, cursor stri
 }
 
 func (c *Client) GetOrganizationMember(ctx context.Context, orgID, memberID string) (*DetailedMember, *v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(OrganizationOneMemberUrl, orgID, memberID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.OrganizationOneMemberURL(orgID, memberID), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -84,7 +84,7 @@ func (c *Client) AddMemberToOrganization(ctx context.Context, orgID string, memb
 		return nil, nil, fmt.Errorf("failed to marshal member: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf(OrganizationMembersUrl, orgID), bytes.NewReader(v))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.OrganizationMembersURL(orgID), bytes.NewReader(v))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -109,7 +109,7 @@ func (c *Client) UpdateOrganizationMemberRole(ctx context.Context, orgID, member
 		return nil, nil, fmt.Errorf("failed to marshal update member role body: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, fmt.Sprintf(OrganizationOneMemberUrl, orgID, memberID), bytes.NewReader(v))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.OrganizationOneMemberURL(orgID, memberID), bytes.NewReader(v))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -125,7 +125,7 @@ func (c *Client) UpdateOrganizationMemberRole(ctx context.Context, orgID, member
 }
 
 func (c *Client) DeleteMemberFromOrganization(ctx context.Context, orgID, userID string) (*v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf(OrganizationOneMemberUrl, orgID, userID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.OrganizationOneMemberURL(orgID, userID), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/projects.go
+++ b/pkg/client/projects.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *Client) ListProjects(ctx context.Context, orgID, cursor string) ([]Project, string, *v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(OrganizationProjectsUrl, orgID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.OrganizationProjectsURL(orgID), nil)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -34,7 +34,7 @@ func (c *Client) ListProjects(ctx context.Context, orgID, cursor string) ([]Proj
 }
 
 func (c *Client) ListTeamProjects(ctx context.Context, orgID, teamID, cursor string) ([]Project, string, *v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(TeamProjectsUrl, orgID, teamID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.TeamProjectsURL(orgID, teamID), nil)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -61,7 +61,7 @@ func (c *Client) ListTeamProjects(ctx context.Context, orgID, teamID, cursor str
 // https://docs.sentry.io/api/projects/list-a-projects-organization-members/
 // Returns a list of active organization members that belong to any team assigned to the project.
 func (c *Client) ListProjectMembers(ctx context.Context, orgID, projectID, cursor string) ([]ProjectMember, string, *v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(ProjectMembersUrl, orgID, projectID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.ProjectMembersURL(orgID, projectID), nil)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -86,7 +86,7 @@ func (c *Client) ListProjectMembers(ctx context.Context, orgID, projectID, curso
 }
 
 func (c *Client) AddTeamToProject(ctx context.Context, orgID, projectID, teamID string) (*v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf(ProvisionProjectTeamUrl, orgID, projectID, teamID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.ProvisionProjectTeamURL(orgID, projectID, teamID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (c *Client) AddTeamToProject(ctx context.Context, orgID, projectID, teamID 
 }
 
 func (c *Client) DeleteTeamFromProject(ctx context.Context, orgID, projectID, teamID string) (*v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf(ProvisionProjectTeamUrl, orgID, projectID, teamID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.ProvisionProjectTeamURL(orgID, projectID, teamID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (c *Client) DeleteTeamFromProject(ctx context.Context, orgID, projectID, te
 }
 
 func (c *Client) GetProject(ctx context.Context, orgID, projectID string) (*DetailedProject, *v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(ProjectsUrl, orgID, projectID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.ProjectsURL(orgID, projectID), nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/client/teams.go
+++ b/pkg/client/teams.go
@@ -11,7 +11,7 @@ import (
 // docs: https://docs.sentry.io/api/teams/
 
 func (c *Client) ListTeams(ctx context.Context, orgID, cursor string) ([]Team, string, *v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(OrganizationTeamsUrl, orgID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.OrganizationTeamsURL(orgID), nil)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -36,7 +36,7 @@ func (c *Client) ListTeams(ctx context.Context, orgID, cursor string) ([]Team, s
 }
 
 func (c *Client) ListTeamMembers(ctx context.Context, orgID, teamID, cursor string) ([]TeamMember, string, *v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(TeamMembersUrl, orgID, teamID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.TeamMembersURL(orgID, teamID), nil)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -61,7 +61,7 @@ func (c *Client) ListTeamMembers(ctx context.Context, orgID, teamID, cursor stri
 }
 
 func (c *Client) AddOrgMemberToTeam(ctx context.Context, orgID, memberID, teamID string) (*v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf(ProvisionTeamMemberUrl, orgID, memberID, teamID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.ProvisionTeamMemberURL(orgID, memberID, teamID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (c *Client) AddOrgMemberToTeam(ctx context.Context, orgID, memberID, teamID
 }
 
 func (c *Client) DeleteOrgMemberFromTeam(ctx context.Context, orgID, memberID, teamID string) (*v2.RateLimitDescription, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf(ProvisionTeamMemberUrl, orgID, memberID, teamID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.ProvisionTeamMemberURL(orgID, memberID, teamID), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/urls.go
+++ b/pkg/client/urls.go
@@ -1,33 +1,81 @@
 package client
 
+import "fmt"
+
+// Path patterns (relative to base URL).
 const (
-	BaseUrl                  = "https://sentry.io/api/0/"
-	OrganizationsUrl         = BaseUrl + "organizations/"
-	OrganizationMembersUrl   = OrganizationsUrl + "%s/members/"
-	OrganizationOneMemberUrl = OrganizationsUrl + "%s/members/%s/"
-	OrganizationTeamsUrl     = OrganizationsUrl + "%s/teams/"
-	OrganizationProjectsUrl  = OrganizationsUrl + "%s/projects/"
+	organizationsPath         = "organizations/"
+	organizationMembersPath   = "organizations/%s/members/"
+	organizationOneMemberPath = "organizations/%s/members/%s/"
+	organizationTeamsPath     = "organizations/%s/teams/"
+	organizationProjectsPath  = "organizations/%s/projects/"
 
 	//https://docs.sentry.io/api/teams/list-a-teams-members/
 	//	teams/{organization_id_or_slug}/{team_id_or_slug}/members/
-	TeamMembersUrl = BaseUrl + "teams/%s/%s/members/"
+	teamMembersPath = "teams/%s/%s/members/"
 
 	//- grant team member https://docs.sentry.io/api/teams/add-an-organization-member-to-a-team/
 	//- revoke team member https://docs.sentry.io/api/teams/delete-an-organization-member-from-a-team/
 	//
 	//	organizations/{organization_id_or_slug}/members/{member_id}/teams/{team_id_or_slug}/
-	ProvisionTeamMemberUrl = OrganizationMembersUrl + "%s/teams/%s/"
+	provisionTeamMemberPath = "organizations/%s/members/%s/teams/%s/"
 
 	//	projects/{organization_id_or_slug}/{project_id_or_slug}/
-	ProjectsUrl = BaseUrl + "projects/%s/%s/"
+	projectsPath = "projects/%s/%s/"
 
-	//	projects/{organization_id_or_slug}/{project_id_or_slug}/
-	ProjectMembersUrl = ProjectsUrl + "members/"
+	//	projects/{organization_id_or_slug}/{project_id_or_slug}/members/
+	projectMembersPath = "projects/%s/%s/members/"
 
 	// provision project members
 	//	projects/{organization_id_or_slug}/{project_id_or_slug}/teams/{team_id_or_slug}/
-	ProvisionProjectTeamUrl = ProjectsUrl + "teams/%s/"
+	provisionProjectTeamPath = "projects/%s/%s/teams/%s/"
 
 	// teams/{organization_id_or_slug}/{team_id_or_slug}/projects/.
-	TeamProjectsUrl = BaseUrl + "teams/%s/%s/projects/"
+	teamProjectsPath = "teams/%s/%s/projects/"
 )
+
+// URL builder methods.
+
+func (c *Client) OrganizationsURL() string {
+	return c.baseURL + organizationsPath
+}
+
+func (c *Client) OrganizationMembersURL(orgID string) string {
+	return c.baseURL + fmt.Sprintf(organizationMembersPath, orgID)
+}
+
+func (c *Client) OrganizationOneMemberURL(orgID, memberID string) string {
+	return c.baseURL + fmt.Sprintf(organizationOneMemberPath, orgID, memberID)
+}
+
+func (c *Client) OrganizationTeamsURL(orgID string) string {
+	return c.baseURL + fmt.Sprintf(organizationTeamsPath, orgID)
+}
+
+func (c *Client) OrganizationProjectsURL(orgID string) string {
+	return c.baseURL + fmt.Sprintf(organizationProjectsPath, orgID)
+}
+
+func (c *Client) TeamMembersURL(orgID, teamID string) string {
+	return c.baseURL + fmt.Sprintf(teamMembersPath, orgID, teamID)
+}
+
+func (c *Client) ProvisionTeamMemberURL(orgID, memberID, teamID string) string {
+	return c.baseURL + fmt.Sprintf(provisionTeamMemberPath, orgID, memberID, teamID)
+}
+
+func (c *Client) ProjectsURL(orgID, projectID string) string {
+	return c.baseURL + fmt.Sprintf(projectsPath, orgID, projectID)
+}
+
+func (c *Client) ProjectMembersURL(orgID, projectID string) string {
+	return c.baseURL + fmt.Sprintf(projectMembersPath, orgID, projectID)
+}
+
+func (c *Client) ProvisionProjectTeamURL(orgID, projectID, teamID string) string {
+	return c.baseURL + fmt.Sprintf(provisionProjectTeamPath, orgID, projectID, teamID)
+}
+
+func (c *Client) TeamProjectsURL(orgID, teamID string) string {
+	return c.baseURL + fmt.Sprintf(teamProjectsPath, orgID, teamID)
+}

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -5,6 +5,7 @@ import "reflect"
 
 type Sentry struct {
 	ApiToken string `mapstructure:"api-token"`
+	BaseUrl  string `mapstructure:"base-url"`
 }
 
 func (c* Sentry) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Sentry API URL (for testing or self-hosted)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	ConfigurationFields = []field.SchemaField{ApiToken, BaseURL}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ var (
 	BaseURL = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Sentry API URL (for testing or self-hosted)"),
+		field.WithHidden(true),
 	)
 
 	ConfigurationFields = []field.SchemaField{ApiToken, BaseURL}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,8 +13,12 @@ var (
 		field.WithIsSecret(true),
 		field.WithRequired(true),
 	)
+	BaseURL = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Sentry API URL (for testing or self-hosted)"),
+	)
 
-	ConfigurationFields = []field.SchemaField{ApiToken}
+	ConfigurationFields = []field.SchemaField{ApiToken, BaseURL}
 
 	// FieldRelationships defines relationships between the ConfigurationFields that can be automatically validated.
 	// For example, a username and password can be required together, or an access token can be

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -79,8 +79,8 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apiToken string) (*Connector, error) {
-	client, err := client.New(ctx, apiToken)
+func New(ctx context.Context, apiToken string, baseURL string) (*Connector, error) {
+	client, err := client.New(ctx, apiToken, baseURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -10,6 +10,8 @@ import (
 	"github.com/conductorone/baton-sentry/pkg/client"
 )
 
+const orgIDKey = "org_id"
+
 type Connector struct {
 	client *client.Client
 }

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -26,7 +26,7 @@ func (o *projectBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 
 func newProjectResource(project client.Project, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"org_id":    parentResourceID.Resource,
+		orgIDKey:    parentResourceID.Resource,
 		"team_id":   project.ID,
 		"is_public": project.IsPublic,
 		"status":    project.Status,

--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -26,7 +26,7 @@ func (o *teamBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 
 func newTeamResource(team client.Team, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
 	profile := map[string]interface{}{
-		"org_id": parentResourceID.Resource,
+		orgIDKey: parentResourceID.Resource,
 	}
 	return resourceSdk.NewGroupResource(
 		team.Name,

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -24,7 +24,7 @@ func newUserResource(member client.OrganizationMember, parentResourceID *v2.Reso
 	profile := map[string]interface{}{
 		"expired":       member.Expired,
 		"invite_status": member.InviteStatus,
-		"org_id":        parentResourceID.Resource,
+		orgIDKey:        parentResourceID.Resource,
 	}
 
 	return resourceSdk.NewUserResource(


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-sentry/main.go,pkg/client/client.go,pkg/client/organizations.go,pkg/client/projects.go,pkg/client/teams.go,pkg/client/urls.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-sentry --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.