### PR TITLE
fix: read email from AccountInfo.Emails instead of Profile map

### DIFF
--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -101,10 +101,22 @@ func (o *userBuilder) CreateAccount(ctx context.Context, accountInfo *v2.Account
 	annotations.Annotations,
 	error,
 ) {
-	pMap := accountInfo.Profile.AsMap()
-	email, ok := pMap["email"].(string)
-	if !ok {
-		return nil, nil, nil, fmt.Errorf("baton-sentry: email not found in profile")
+	// Read email from the structured Emails field (how the C1 platform sends it)
+	var email string
+	for _, e := range accountInfo.GetEmails() {
+		if e.GetIsPrimary() {
+			email = e.GetAddress()
+			break
+		}
+	}
+
+	// Fall back to profile map for backward compatibility
+	pMap := accountInfo.GetProfile().AsMap()
+	if email == "" {
+		email, _ = pMap["email"].(string)
+	}
+	if email == "" {
+		return nil, nil, nil, fmt.Errorf("baton-sentry: email not found in account info")
 	}
 
 	orgId, ok := pMap["orgID"].(string)


### PR DESCRIPTION
## Summary

The `CreateAccount` method in `pkg/connector/users.go` reads the user's email from `accountInfo.Profile` (a free-form protobuf Struct map), but the ConductorOne platform sends the email in `accountInfo.Emails` (the structured `repeated Email` field on `AccountInfo`).

This causes **"email not found in profile"** errors during account provisioning, even when the user's email is correctly set in ConductorOne.

## Root Cause

```go
// Before (broken): reads from Profile map, which C1 doesn't populate with email
pMap := accountInfo.Profile.AsMap()
email, ok := pMap["email"].(string)
```

The `AccountInfo` protobuf has two separate places for email:
- `repeated Email emails = 1` — structured field (where C1 sends the email)
- `google.protobuf.Struct profile = 4` — free-form map (where the connector was looking)

## Fix

Now reads from `accountInfo.GetEmails()` first, with a fallback to the Profile map for backward compatibility.

This matches the pattern used by other connectors (e.g., baton-sendgrid).

## Test plan

- Verified the fix reads from the correct field by tracing the protobuf message structure
- Cross-referenced with baton-sendgrid which handles this correctly
- Backward compatible: still falls back to Profile map if Emails field is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved account creation email handling by implementing more robust email retrieval from account information with better fallback mechanisms and clearer error messages when email data cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->