### PR TITLE
docs: fix connector doc regressions

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -72,7 +72,7 @@ Your new token is created. In the **AUTH TOKENS** section of the page, carefully
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Optional: filter synced organizations
 
@@ -131,7 +131,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your Sentry connector is now pulling access data into C1.
+**Done.** Your Sentry connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -252,7 +252,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Sentry connector to. Sentry data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your Sentry connector is now pulling access data into C1.
+**Done.** Your Sentry connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

This PR corrects issues in the connector docs that were caught during a sync to the ConductorOne docs site. Specific fixes:

- Restore `**Done.**` closing phrase (3 instances; replaces `**That's it!**`)

These corrections prevent the sync bot from reintroducing regressions on future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)