### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/organizations.go
+++ b/pkg/connector/organizations.go
@@ -52,9 +52,8 @@ func newOrgResource(org client.Organization) (*v2.Resource, error) {
 	return resourceSdk.NewGroupResource(
 		org.Name, organizationResourceType,
 		org.ID,
-		[]resourceSdk.GroupTraitOption{
-			resourceSdk.WithGroupProfile(profile),
-		},
+		[]resourceSdk.GroupTraitOption{},
+		resourceSdk.WithResourceProfile(profile),
 		resourceSdk.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: userResourceType.Id},
 			&v2.ChildResourceType{ResourceTypeId: teamResourceType.Id},

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -35,9 +35,8 @@ func newProjectResource(project client.Project, parentResourceID *v2.ResourceId)
 		project.Name,
 		projectResourceType,
 		project.ID,
-		[]resourceSdk.GroupTraitOption{
-			resourceSdk.WithGroupProfile(profile),
-		},
+		[]resourceSdk.GroupTraitOption{},
+		resourceSdk.WithResourceProfile(profile),
 		resourceSdk.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/teams.go
+++ b/pkg/connector/teams.go
@@ -33,9 +33,8 @@ func newTeamResource(team client.Team, parentResourceID *v2.ResourceId) (*v2.Res
 		teamResourceType,
 		// <orgID>/<teamID>
 		fmt.Sprintf("%s/%s", parentResourceID.Resource, team.ID),
-		[]resourceSdk.GroupTraitOption{
-			resourceSdk.WithGroupProfile(profile),
-		},
+		[]resourceSdk.GroupTraitOption{},
+		resourceSdk.WithResourceProfile(profile),
 		resourceSdk.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -33,9 +33,9 @@ func newUserResource(member client.OrganizationMember, parentResourceID *v2.Reso
 		member.ID,
 		[]resourceSdk.UserTraitOption{
 			resourceSdk.WithEmail(member.Email, true),
-			resourceSdk.WithUserProfile(profile),
-			resourceSdk.WithCreatedAt(member.DateCreated),
 		},
+		resourceSdk.WithResourceProfile(profile),
+		resourceSdk.WithResourceCreatedAt(member.DateCreated),
 		resourceSdk.WithParentResourceID(parentResourceID),
 	)
 }


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
